### PR TITLE
Create /etc/modules-load.d if it does not exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ clean:
 
 install:
 	make -C $(BUILD_DIR) M=$(CURDIR) modules_install
+	mkdir -p /etc/modules-load.d
 	modprobe veikk
 	echo "veikk" > /etc/modules-load.d/veikk.conf
 


### PR DESCRIPTION
On some system the directory /etc/modules-load.d does not already exist, which will cause the make install process to fail.
The added line adds the folder if it does not already exist, allowing it to install without problems.